### PR TITLE
Use the most recent patch level rubies for travis specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
   - 2.2.10
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
 
 before_install: gem install bundler


### PR DESCRIPTION
We referred to the `2.3.7` version of ruby, which is no longer available.