### PR TITLE
Make it easier to present objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ Writing your own presenter is really just a matter of subclassing:
 
 Then you are ready to fill your presenter with methods!
 
+Helpers:
+--------
+
+We have provided a helper to make it easier to present models in view contexts.
+Include the presenter helper in a view helper like this:
+
+    require 'substance/rails/view_helper'
+
+    module PresentersHelper
+      include SubstancePresenter::Rails::ViewHelper
+    end
+
+Which gives you the possibility to present an object:
+
+    presented_object = present(object, Substance::Presenter)
+
 License
 -------
 

--- a/lib/substance/rails/view_helper.rb
+++ b/lib/substance/rails/view_helper.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "substance/presenter"
+
+module Substance
+  class Presenter
+    module Rails
+      module ViewHelper
+        # Returns object wrapped in presenter.
+        # If object is a collection each member
+        # of the collection is wrapped and the collection is returned.
+        #
+        # Example
+        #
+        #    <%- @foo = present(@foo, FooPresenter) -%>
+        #
+        def present(object, presenter)
+          if object.is_a?(Enumerable)
+            presenter.present_collection(object, self)
+          else
+            presenter.present(object, self)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,3 +4,4 @@ require 'bundler/setup'
 Bundler.setup
 
 require 'substance/presenter'
+require 'substance/rails/view_helper'

--- a/spec/substance/rails/view_helper_spec.rb
+++ b/spec/substance/rails/view_helper_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "substance/presenter"
+require "substance/rails/view_helper"
+require "spec_helper"
+
+RSpec.describe Substance::Presenter::Rails::ViewHelper do
+  describe "present" do
+    class TestObject
+      def greeting
+        "Hello from the object"
+      end
+    end
+
+    class TestObjectPresenter < Substance::Presenter
+      def decorated_greeting
+        "Hello from the presenter"
+      end
+    end
+
+    class TestHelperClass
+      include Substance::Presenter::Rails::ViewHelper
+    end
+
+    module TestHelperModule
+      include Substance::Presenter::Rails::ViewHelper
+      module_function :present
+    end
+
+    it "can be included in another class" do
+      expect(TestHelperClass.new).to respond_to(:present)
+    end
+
+    it "can be included in another module" do
+      expect(TestHelperModule).to respond_to(:present)
+    end
+
+    describe "#present" do
+      subject { TestHelperModule.new }
+
+      it "can present a collection" do
+        presented_collection = TestHelperModule.present(
+          [TestObject.new, TestObject.new],
+          TestObjectPresenter
+        )
+
+        expect(
+          presented_collection.all?(&:decorated_greeting)
+        ).to be_truthy
+      end
+
+      it "can present a single object" do
+        expect(
+          TestHelperModule.present(
+            TestObject.new,
+            TestObjectPresenter
+          )
+        ).to respond_to(:decorated_greeting)
+      end
+    end
+  end
+end

--- a/spec/substance/substance_presenter_spec.rb
+++ b/spec/substance/substance_presenter_spec.rb
@@ -16,16 +16,17 @@ RSpec.describe Substance::Presenter do
     end
   end
 
-  let(:object) {
+  let(:object) do
     TestObject.new
-  }
-  let(:view_context) {
-    Object.new
-  }
+  end
 
-  subject(:presented_object) {
+  let(:view_context) do
+    Object.new
+  end
+
+  subject(:presented_object) do
     TestObjectPresenter.new(object, view_context)
-  }
+  end
 
   it "decorates the object" do
     expect(subject.decorated_greeting).to eq("Hello from the presenter")

--- a/substance_presenter.gemspec
+++ b/substance_presenter.gemspec
@@ -1,13 +1,12 @@
 Gem::Specification.new do |s|
   s.name        = 'substance_presenter'
   s.version     = '0.9.0'
-  s.date        = '2018-05-10'
   s.summary     = "An easy to use presenter implementation"
   s.description = s.summary
   s.authors     = ["Ole Palm", "Jakob Skjerning", "Jakob Dam Jensen"]
-  s.email       = "ole.palm@substancelab.com"
-  s.files       = Dir["{lib}/*"] + ["Rakefile"]
-  s.homepage    =
-    'http://rubygems.org/gems/substance_presenter'
-  s.license       = 'MIT'
+  s.email = "ole.palm@substancelab.com"
+  s.files = Dir["{lib}/**/*"] + ["Rakefile"]
+  s.homepage = \
+    "https://github.com/substancelab/substance_presenter"
+  s.license = 'MIT'
 end


### PR DESCRIPTION
Fixes #4 

By adding a helper module

`present(object, SomePresenter)` should make it easier.
The object can even be a collection.

- Update readme with ViewHelper documentation and update the existing usage examples with subclassing documentation.
- Cleanup syntax and line length
- Update gemspec