### PR TITLE
Ensure we update the bundler to the newest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,6 @@ rvm:
   - 2.4.5
   - 2.5.3
 
-before_install: gem install bundler
+before_install:
+  - gem update --system
+  - gem install bundler


### PR DESCRIPTION
This fixes the CI error:

``ERROR:  Error installing bundler:
bundler requires Ruby version >= 2.3.0.
The command "gem install bundler" failed and exited with 1 during .``

Following instructions for Bundler 2 at https://docs.travis-ci.com/user/languages/ruby/