### PR TITLE
Update the ruby versions to test against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: ruby
 rvm:
-  - 2.2.10
   - 2.3.8
-  - 2.4.5
-  - 2.5.3
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
+  - 2.7.0-preview1
 
 before_install:
   - gem update --system


### PR DESCRIPTION
Supporting 2.3.8+ onwards, dropping < 2.3.0 ruby support.

Mainly due to issues with rubygems-update on CI.