### PR TITLE
Bundler 2 needs Ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ rvm:
 
 before_install:
   - gem update --system
-  - gem install bundler
+  - gem install bundler -v "1.17.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ rvm:
   - 2.5.3
 
 before_install:
-  - gem update --system
+  - gem update --system "2.7.10"
   - gem install bundler -v "1.17.3"


### PR DESCRIPTION
In order to keep testing on Ruby 2.2, we need an older version of Bundler