### PR TITLE
Test against supported Rubies only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ rvm:
   - 2.5.7
   - 2.6.5
   - 2.7.0-preview2
+matrix:
+  allow_failures:
+    - rvm: 2.7.0-preview2
 
 before_install:
   - gem update --system "2.7.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 rvm:
-  - 2.2.10
-  - 2.3.8
-  - 2.4.5
-  - 2.5.3
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
+  - 2.7.0-preview2
 
 before_install:
   - gem update --system "2.7.10"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# Unreleased
+
+### Added
+
+- Support for Ruby 2.6 and 2.7 (the latter of which is currently in preview)
+
+### Removed
+
+- Support for Ruby 2.2 and 2.3 that are both EOL. We probably still support
+  and work on those versions, but we won't verify and test them any more.
+
 # 0.9.1
+
 ##  FEATURES
+
 - Added a view helper for the presenter


### PR DESCRIPTION
This removes official support for both Ruby 2.2 and 2.3, which are both EOL. To
compensate, this adds support for 2.6 and 2.7.